### PR TITLE
Fixed build failure on windows.

### DIFF
--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -8,6 +8,7 @@
 
 #ifdef _WIN32
     #pragma warning(disable:4996)
+    #define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
 #endif
 
 #define ARC_SEGMENTS_PER_PI 2


### PR DESCRIPTION
The windows equivalent to strncasecmp is _strnicmp.

1>  import-svg.cpp
1>ext\import-svg.cpp(81): error C3861: 'strncasecmp': identifier not found
1>ext\import-svg.cpp(87): error C3861: 'strncasecmp': identifier not found
1>ext\import-svg.cpp(92): error C3861: 'strncasecmp': identifier not found