### PR TITLE
Fixed precision of median calculation in legacy generateMSDF.

### DIFF
--- a/core/msdfgen.cpp
+++ b/core/msdfgen.cpp
@@ -306,9 +306,9 @@ void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, co
                 if (sb.nearEdge)
                     (*sb.nearEdge)->distanceToPseudoDistance(sb.minDistance, p, sb.nearParam);
 
-                float dr = sr.minDistance.distance;
-                float dg = sg.minDistance.distance;
-                float db = sb.minDistance.distance;
+                double dr = sr.minDistance.distance;
+                double dg = sg.minDistance.distance;
+                double db = sb.minDistance.distance;
                 
                 double med = median(dr, dg, db);
                 // Note: Use signbit() not sign() here because we need to know -0 case.


### PR DESCRIPTION
Caught as a warning by vs2015.
1>  msdfgen.cpp
1>core\msdfgen.cpp(309): warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data
1>core\msdfgen.cpp(310): warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data
1>core\msdfgen.cpp(311): warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data