### PR TITLE
Optimization for complex shapes

### DIFF
--- a/Contour.cpp
+++ b/Contour.cpp
@@ -1,0 +1,64 @@
+
+#include "Contour.h"
+
+#include "arithmetics.hpp"
+
+namespace msdfgen {
+
+static double shoelace(const Point2 &a, const Point2 &b) {
+    return (b.x-a.x)*(a.y+b.y);
+}
+
+void Contour::addEdge(const EdgeHolder &edge) {
+    edges.push_back(edge);
+}
+
+#ifdef MSDFGEN_USE_CPP11
+void Contour::addEdge(EdgeHolder &&edge) {
+    edges.push_back((EdgeHolder &&) edge);
+}
+#endif
+
+EdgeHolder & Contour::addEdge() {
+    edges.resize(edges.size()+1);
+    return edges[edges.size()-1];
+}
+
+void Contour::bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const {
+    for (std::vector<EdgeHolder>::const_iterator edge = edges.begin(); edge != edges.end(); ++edge)
+        (*edge)->bounds(l, b, r, t, circleBounds);
+}
+
+void Contour::circleBounds(CircleBounds& b) const
+{
+    for ( std::vector<EdgeHolder>::const_iterator edge = edges.begin(); edge != edges.end(); ++edge )
+        (*edge)->circleBounds( b );
+}
+
+int Contour::winding() const {
+    if (edges.empty())
+        return 0;
+    double total = 0;
+    if (edges.size() == 1) {
+        Point2 a = edges[0]->point(0), b = edges[0]->point(1/3.), c = edges[0]->point(2/3.);
+        total += shoelace(a, b);
+        total += shoelace(b, c);
+        total += shoelace(c, a);
+    } else if (edges.size() == 2) {
+        Point2 a = edges[0]->point(0), b = edges[0]->point(.5), c = edges[1]->point(0), d = edges[1]->point(.5);
+        total += shoelace(a, b);
+        total += shoelace(b, c);
+        total += shoelace(c, d);
+        total += shoelace(d, a);
+    } else {
+        Point2 prev = edges[edges.size()-1]->point(0);
+        for (std::vector<EdgeHolder>::const_iterator edge = edges.begin(); edge != edges.end(); ++edge) {
+            Point2 cur = (*edge)->point(0);
+            total += shoelace(prev, cur);
+            prev = cur;
+        }
+    }
+    return sign(total);
+}
+
+}

--- a/Contour.h
+++ b/Contour.h
@@ -1,0 +1,32 @@
+
+#pragma once
+
+#include <vector>
+#include "EdgeHolder.h"
+
+namespace msdfgen {
+
+/// A single closed contour of a shape.
+class Contour {
+
+public:
+    /// The sequence of edges that make up the contour.
+    std::vector<EdgeHolder> edges;
+
+    /// Adds an edge to the contour.
+    void addEdge(const EdgeHolder &edge);
+#ifdef MSDFGEN_USE_CPP11
+    void addEdge(EdgeHolder &&edge);
+#endif
+    /// Creates a new edge in the contour and returns its reference.
+    EdgeHolder & addEdge();
+    /// Computes the bounding box of the contour.
+    void bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const;
+    /// Computes the bounding circle of the contour.
+    void circleBounds(CircleBounds& b) const;
+    /// Computes the winding of the contour. Returns 1 if positive, -1 if negative.
+    int winding() const;
+
+};
+
+}

--- a/Shape.cpp
+++ b/Shape.cpp
@@ -1,0 +1,88 @@
+
+#include "Shape.h"
+
+namespace msdfgen {
+
+Shape::Shape() : inverseYAxis(false), fillRule(FillRule::NonZero) { }
+
+void Shape::addContour(const Contour &contour) {
+    contours.push_back(contour);
+}
+
+#ifdef MSDFGEN_USE_CPP11
+void Shape::addContour(Contour &&contour) {
+    contours.push_back((Contour &&) contour);
+}
+#endif
+
+Contour & Shape::addContour() {
+    contours.resize(contours.size()+1);
+    return contours[contours.size()-1];
+}
+
+bool Shape::validate() const {
+    for (std::vector<Contour>::const_iterator contour = contours.begin(); contour != contours.end(); ++contour) {
+        if (!contour->edges.empty()) {
+            Point2 corner = (*(contour->edges.end()-1))->point(1);
+            for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                if (!*edge)
+                    return false;
+                if (!(*edge)->point(0).same(corner) )
+                    return false;
+                corner = (*edge)->point(1);
+            }
+        }
+    }
+    return true;
+}
+
+void Shape::normalize() {
+    for (std::vector<Contour>::iterator contour = contours.begin(); contour != contours.end(); ++contour) {
+        // First, erase all degenerate edges.
+        std::vector<EdgeHolder>::iterator edge_it = contour->edges.begin();
+        while( edge_it != contour->edges.end() ) {
+            if( (*edge_it)->isDegenerate() ) {
+                edge_it = contour->edges.erase(edge_it);
+            }
+            else {
+                edge_it++;
+            }
+        }
+        
+        if (contour->edges.size() == 1) {
+            EdgeSegment *parts[3] = { };
+            contour->edges[0]->splitInThirds(parts[0], parts[1], parts[2]);
+            contour->edges.clear();
+            contour->edges.push_back(EdgeHolder(parts[0]));
+            contour->edges.push_back(EdgeHolder(parts[1]));
+            contour->edges.push_back(EdgeHolder(parts[2]));
+        }
+        else {
+            
+            // Make sure that start points match end points exactly or we'll get artifacts.
+            int n = contour->edges.size();
+            for( int i = 0; i < n; i++ )
+            {
+                EdgeSegment *s1 = contour->edges[i];
+                EdgeSegment *s2 = contour->edges[(i + 1) % n];
+                if( s1->point(1) != s2->point(0) )
+                {
+                    s1->moveEndPoint(s2->point(0));
+                }
+            }
+        }
+    }
+}
+
+void Shape::bounds(double &l, double &b, double &r, double &t, std::vector<CircleBounds>* contourBounds) const {
+    for ( std::vector<Contour>::const_iterator contour = contours.begin(); contour != contours.end(); ++contour )
+    {
+        if ( contourBounds )
+        {
+            contourBounds->push_back( CircleBounds() );
+        }
+        contour->bounds( l, b, r, t, contourBounds ? &contourBounds->back() : nullptr );
+    }
+}
+
+}

--- a/Shape.h
+++ b/Shape.h
@@ -1,0 +1,45 @@
+
+#pragma once
+
+#include <vector>
+#include "Contour.h"
+
+namespace msdfgen {
+    
+    /// Fill rules compatible with SVG: https://www.w3.org/TR/SVG/painting.html#FillRuleProperty
+    enum FillRule {
+        None = 0, // Legacy
+        NonZero = 1,
+        EvenOdd = 2,
+    };
+
+/// Vector shape representation.
+class Shape {
+
+public:
+    /// The list of contours the shape consists of.
+    std::vector<Contour> contours;
+    /// Specifies whether the shape uses bottom-to-top (false) or top-to-bottom (true) Y coordinates.
+    bool inverseYAxis;
+    /// Fill rule for this shape.
+    FillRule fillRule;
+    
+
+    Shape();
+    /// Adds a contour.
+    void addContour(const Contour &contour);
+#ifdef MSDFGEN_USE_CPP11
+    void addContour(Contour &&contour);
+#endif
+    /// Adds a blank contour and returns its reference.
+    Contour & addContour();
+    /// Normalizes the shape geometry for distance field generation.
+    void normalize();
+    /// Performs basic checks to determine if the object represents a valid shape.
+    bool validate() const;
+    /// Computes the shape's bounding box.
+    void bounds(double &l, double &b, double &r, double &t, std::vector<CircleBounds>* contourBounds = nullptr) const;
+
+};
+
+}

--- a/edge-segments.cpp
+++ b/edge-segments.cpp
@@ -1,0 +1,625 @@
+
+#include "edge-segments.h"
+
+#include "arithmetics.hpp"
+#include "equation-solver.h"
+
+namespace msdfgen {
+
+void EdgeSegment::distanceToPseudoDistance(SignedDistance &distance, Point2 origin, double param) const {
+    if (param < 0) {
+        Vector2 dir = direction(0).normalize();
+        Vector2 aq = origin-point(0);
+        double ts = dotProduct(aq, dir);
+        if (ts < 0) {
+            double pseudoDistance = crossProduct(aq, dir);
+            if (fabs(pseudoDistance) <= fabs(distance.distance)) {
+                distance.distance = pseudoDistance;
+                distance.dot = 0;
+            }
+        }
+    } else if (param > 1) {
+        Vector2 dir = direction(1).normalize();
+        Vector2 bq = origin-point(1);
+        double ts = dotProduct(bq, dir);
+        if (ts > 0) {
+            double pseudoDistance = crossProduct(bq, dir);
+            if (fabs(pseudoDistance) <= fabs(distance.distance)) {
+                distance.distance = pseudoDistance;
+                distance.dot = 0;
+            }
+        }
+    }
+}
+
+LinearSegment::LinearSegment(Point2 p0, Point2 p1, EdgeColor edgeColor) : EdgeSegment(edgeColor) {
+    p[0] = p0;
+    p[1] = p1;
+}
+
+QuadraticSegment::QuadraticSegment(Point2 p0, Point2 p1, Point2 p2, EdgeColor edgeColor) : EdgeSegment(edgeColor) {
+    if (p1 == p0 || p1 == p2)
+        p1 = 0.5*(p0+p2);
+    p[0] = p0;
+    p[1] = p1;
+    p[2] = p2;
+}
+
+CubicSegment::CubicSegment(Point2 p0, Point2 p1, Point2 p2, Point2 p3, EdgeColor edgeColor) : EdgeSegment(edgeColor) {
+    p[0] = p0;
+    p[1] = p1;
+    p[2] = p2;
+    p[3] = p3;
+}
+
+LinearSegment * LinearSegment::clone() const {
+    return new LinearSegment(p[0], p[1], color);
+}
+
+QuadraticSegment * QuadraticSegment::clone() const {
+    return new QuadraticSegment(p[0], p[1], p[2], color);
+}
+
+CubicSegment * CubicSegment::clone() const {
+    return new CubicSegment(p[0], p[1], p[2], p[3], color);
+}
+
+Point2 LinearSegment::point(double param) const {
+    return mix(p[0], p[1], param);
+}
+
+Point2 QuadraticSegment::point(double param) const {
+    return mix(mix(p[0], p[1], param), mix(p[1], p[2], param), param);
+}
+
+Point2 CubicSegment::point(double param) const {
+    Vector2 p12 = mix(p[1], p[2], param);
+    return mix(mix(mix(p[0], p[1], param), p12, param), mix(p12, mix(p[2], p[3], param), param), param);
+}
+
+Vector2 LinearSegment::direction(double param) const {
+    return p[1]-p[0];
+}
+
+Vector2 QuadraticSegment::direction(double param) const {
+    return mix(p[1]-p[0], p[2]-p[1], param);
+}
+
+Vector2 CubicSegment::direction(double param) const {
+    Vector2 tangent = mix(mix(p[1]-p[0], p[2]-p[1], param), mix(p[2]-p[1], p[3]-p[2], param), param);
+    if (!tangent) {
+        if (param == 0) return p[2]-p[0];
+        if (param == 1) return p[3]-p[1];
+    }
+    return tangent;
+}
+
+SignedDistance LinearSegment::signedDistance(Point2 origin, double &param) const {
+    Vector2 aq = origin-p[0];
+    Vector2 ab = p[1]-p[0];
+    param = dotProduct(aq, ab)/dotProduct(ab, ab);
+    Vector2 eq = p[param > .5]-origin;
+    double endpointDistance = eq.length();
+    if (param > 0 && param < 1) {
+        double orthoDistance = dotProduct(ab.getOrthonormal(false), aq);
+        if (fabs(orthoDistance) < endpointDistance)
+            return SignedDistance(orthoDistance, 0);
+    }
+    return SignedDistance(nonZeroSign(crossProduct(aq, ab))*endpointDistance, fabs(dotProduct(ab.normalize(), eq.normalize())));
+}
+
+SignedDistance QuadraticSegment::signedDistance(Point2 origin, double &param) const {
+    Vector2 qa = p[0]-origin;
+    Vector2 ab = p[1]-p[0];
+    Vector2 br = p[0]+p[2]-p[1]-p[1];
+    double a = dotProduct(br, br);
+    double b = 3*dotProduct(ab, br);
+    double c = 2*dotProduct(ab, ab)+dotProduct(qa, br);
+    double d = dotProduct(qa, ab);
+    double t[3];
+    int solutions = solveCubic(t, a, b, c, d);
+
+    double minDistance = nonZeroSign(crossProduct(ab, qa))*qa.length(); // distance from A
+    param = -dotProduct(qa, ab)/dotProduct(ab, ab);
+    {
+        double distance = nonZeroSign(crossProduct(p[2]-p[1], p[2]-origin))*(p[2]-origin).length(); // distance from B
+        if (fabs(distance) < fabs(minDistance)) {
+            minDistance = distance;
+            param = dotProduct(origin-p[1], p[2]-p[1])/dotProduct(p[2]-p[1], p[2]-p[1]);
+        }
+    }
+    for (int i = 0; i < solutions; ++i) {
+        if (t[i] > 0 && t[i] < 1) {
+            Point2 endpoint = p[0]+2*t[i]*ab+t[i]*t[i]*br;
+            double distance = nonZeroSign(crossProduct(p[2]-p[0], endpoint-origin))*(endpoint-origin).length();
+            if (fabs(distance) <= fabs(minDistance)) {
+                minDistance = distance;
+                param = t[i];
+            }
+        }
+    }
+
+    if (param >= 0 && param <= 1)
+        return SignedDistance(minDistance, 0);
+    if (param < .5)
+        return SignedDistance(minDistance, fabs(dotProduct(ab.normalize(), qa.normalize())));
+    else
+        return SignedDistance(minDistance, fabs(dotProduct((p[2]-p[1]).normalize(), (p[2]-origin).normalize())));
+}
+
+SignedDistance CubicSegment::signedDistance(Point2 origin, double &param) const {
+    Vector2 qa = p[0]-origin;
+    Vector2 ab = p[1]-p[0];
+    Vector2 br = p[2]-p[1]-ab;
+    Vector2 as = (p[3]-p[2])-(p[2]-p[1])-br;
+
+    Vector2 epDir = direction(0);
+    double minDistance = nonZeroSign(crossProduct(epDir, qa))*qa.length(); // distance from A
+    param = -dotProduct(qa, epDir)/dotProduct(epDir, epDir);
+    {
+        epDir = direction(1);
+        double distance = nonZeroSign(crossProduct(epDir, p[3]-origin))*(p[3]-origin).length(); // distance from B
+        if (fabs(distance) < fabs(minDistance)) {
+            minDistance = distance;
+            param = dotProduct(origin+epDir-p[3], epDir)/dotProduct(epDir, epDir);
+        }
+    }
+    // Iterative minimum distance search
+    for (int i = 0; i <= MSDFGEN_CUBIC_SEARCH_STARTS; ++i) {
+        double t = (double) i/MSDFGEN_CUBIC_SEARCH_STARTS;
+        for (int step = 0;; ++step) {
+            Vector2 qpt = point(t)-origin;
+            double distance = nonZeroSign(crossProduct(direction(t), qpt))*qpt.length();
+            if (fabs(distance) < fabs(minDistance)) {
+                minDistance = distance;
+                param = t;
+            }
+            if (step == MSDFGEN_CUBIC_SEARCH_STEPS)
+                break;
+            // Improve t
+            Vector2 d1 = 3*as*t*t+6*br*t+3*ab;
+            Vector2 d2 = 6*as*t+6*br;
+            t -= dotProduct(qpt, d1)/(dotProduct(d1, d1)+dotProduct(qpt, d2));
+            if (t < 0 || t > 1)
+                break;
+        }
+    }
+
+    if (param >= 0 && param <= 1)
+        return SignedDistance(minDistance, 0);
+    if (param < .5)
+        return SignedDistance(minDistance, fabs(dotProduct(direction(0).normalize(), qa.normalize())));
+    else
+        return SignedDistance(minDistance, fabs(dotProduct(direction(1).normalize(), (p[3]-origin).normalize())));
+}
+
+static void pointBounds(Point2 p, double &l, double &b, double &r, double &t) {
+    if (p.x < l) l = p.x;
+    if (p.y < b) b = p.y;
+    if (p.x > r) r = p.x;
+    if (p.y > t) t = p.y;
+}
+
+void LinearSegment::bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const {
+    pointBounds(p[0], l, b, r, t);
+    pointBounds(p[1], l, b, r, t);
+
+    if ( circleBounds )
+    {
+        circleBounds->addPoint( p[0] );
+        circleBounds->addPoint( p[1] );
+    }
+}
+
+void QuadraticSegment::bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const {
+    pointBounds(p[0], l, b, r, t);
+    pointBounds(p[2], l, b, r, t);
+
+    if ( circleBounds )
+    {
+        circleBounds->addPoint( p[0] );
+        circleBounds->addPoint( p[2] );
+    }
+
+    Vector2 bot = (p[1]-p[0])-(p[2]-p[1]);
+    if (bot.x) {
+        double param = (p[1].x-p[0].x)/bot.x;
+        if (param > 0 && param < 1)
+        {
+            Vector2 pt = point( param );
+            pointBounds( pt, l, b, r, t );
+            if ( circleBounds )
+                circleBounds->addPoint( pt );
+        }
+    }
+    if (bot.y) {
+        double param = (p[1].y-p[0].y)/bot.y;
+        if (param > 0 && param < 1)
+        {
+            Vector2 pt = point( param );
+            pointBounds( pt, l, b, r, t );
+            if ( circleBounds )
+                circleBounds->addPoint( pt );
+        }
+    }
+}
+
+void CubicSegment::bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const {
+    pointBounds(p[0], l, b, r, t);
+    pointBounds(p[3], l, b, r, t);
+
+    if ( circleBounds )
+    {
+        circleBounds->addPoint( p[0] );
+        circleBounds->addPoint( p[3] );
+    }
+
+    Vector2 a0 = p[1]-p[0];
+    Vector2 a1 = 2*(p[2]-p[1]-a0);
+    Vector2 a2 = p[3]-3*p[2]+3*p[1]-p[0];
+    double params[2];
+    
+    int solutions;
+    solutions = solveQuadratic(params, a2.x, a1.x, a0.x);
+    
+    for (int i = 0; i < solutions; ++i)
+        if (params[i] > 0 && params[i] < 1)
+        {
+            Vector2 pt = point( params[i] );
+            pointBounds( pt, l, b, r, t );
+            if ( circleBounds )
+                circleBounds->addPoint( pt );
+        }
+    
+    solutions = solveQuadratic(params, a2.y, a1.y, a0.y);
+    
+    for (int i = 0; i < solutions; ++i)
+        if (params[i] > 0 && params[i] < 1)
+        {
+            Vector2 pt = point( params[i] );
+            pointBounds( pt, l, b, r, t );
+            if ( circleBounds )
+                circleBounds->addPoint( pt );
+        }
+}
+
+inline void CircleBounds::circlefromPoints(const Point2& p0, const Point2& p1)
+{
+    centre = (p0 + p1) / 2;
+    radius = (p0 - centre).length();
+}
+
+inline void CircleBounds::circlefromPoints(const Point2& p0, const Point2& p1, const Point2& p2)
+{
+    // Calculate orthogonal lines from mid points of two sides
+    Point2 mid0 = (p1 + p0) / 2;
+    Point2 mid1 = (p2 + p0) / 2;
+
+    Vector2 dir0 = (p1 - p0).getOrthogonal();
+    Vector2 dir1orth = (p2 - p0);
+
+    // centre at intersection of lines
+    double s = dotProduct(mid1 - mid0, dir1orth) / dotProduct( dir0, dir1orth );
+    centre = mid0 + dir0 * s;
+
+    radius = (p0 - centre).length();
+}
+
+void CircleBounds::addPoint( const Point2& p )
+{
+    // Check if point already in circle
+    if ( (p - centre).length() <= radius )
+    {
+        return;
+    }
+
+    switch ( edgePoints.size() )
+    {
+        case 0:
+        {
+            // nothing in bounds, create a point bound
+            centre = p;
+            radius = 0.0;
+            edgePoints.push_back( p );
+        }
+        break;
+
+        case 1:
+        {
+            // point bound, expand to two point circle
+            circlefromPoints( edgePoints.front(), p );
+            edgePoints.push_back( p );
+        }
+        break;
+
+        case 2:
+        {
+            // Check each point with the new point to see if a two point circle is optimal
+            for ( int i = 0; i < 2; ++i )
+            {
+                circlefromPoints( edgePoints[i], p );
+
+                // If other point in new circle then discard it; new bound is two point with other point and p
+                if ( (edgePoints[1 - i] - centre).length() <= radius )
+                {
+                    edgePoints.erase( edgePoints.begin() + 1 - i );
+                    break;
+                }
+            }
+
+            edgePoints.push_back( p );
+
+            // If neither two point circle was optimal then form a three point circle
+            if ( edgePoints.size() == 3 )
+            {
+                circlefromPoints( edgePoints[0], edgePoints[1], edgePoints[2] );
+            }
+        }
+        break;
+
+        case 3:
+        {
+            // Check each point with the new point to see if a two point circle is optimal
+            for ( int i = 0; i < 3; ++i )
+            {
+                circlefromPoints( edgePoints[i], p );
+
+                // If other points in new circle then discard them; new bound is two point with other point and p
+                if ( (edgePoints[(i + 1) % 3] - centre).length() <= radius && (edgePoints[(i + 2) % 3] - centre).length() <= radius )
+                {
+                    Point2 p0 = edgePoints[i];
+                    edgePoints.clear();
+                    edgePoints.push_back( p0 );
+                    break;
+                }
+            }
+
+            // Check each pair of points with the new point to see which three point circle is optimal
+            if ( edgePoints.size() == 3 )
+            {
+                for ( int i = 0; i < 3; ++i )
+                {
+                    circlefromPoints( edgePoints[i], edgePoints[(i + 1) % 3], p );
+
+                    // If other point in new circle then discard it
+                    if ( (edgePoints[(i + 2) % 3] - centre).length() <= radius )
+                    {
+                        edgePoints.erase( edgePoints.begin() + (i + 2) % 3 );
+                        break;
+                    }
+                }
+            }
+
+            if ( edgePoints.size() == 3 )
+            {
+                // Something has gone wrong here...
+                edgePoints.pop_back();
+            }
+
+            edgePoints.push_back( p );
+        }
+        break;
+    }
+}
+
+void LinearSegment::circleBounds(CircleBounds& b) const
+{
+    b.addPoint( p[0] );
+    b.addPoint( p[1] );
+}
+
+void QuadraticSegment::circleBounds(CircleBounds& b) const
+{
+    b.addPoint( p[0] );
+    b.addPoint( p[2] );
+    Vector2 bot = (p[1] - p[0]) - (p[2] - p[1]);
+    if ( bot.x )
+    {
+        double param = (p[1].x - p[0].x) / bot.x;
+        if ( param > 0 && param < 1 )
+            b.addPoint( point( param ) );
+    }
+    if ( bot.y )
+    {
+        double param = (p[1].y - p[0].y) / bot.y;
+        if ( param > 0 && param < 1 )
+            b.addPoint( point( param ) );
+    }
+}
+
+void CubicSegment::circleBounds(CircleBounds& b) const
+{
+    b.addPoint( p[0] );
+    b.addPoint( p[3] );
+    Vector2 a0 = p[1] - p[0];
+    Vector2 a1 = 2 * (p[2] - p[1] - a0);
+    Vector2 a2 = p[3] - 3 * p[2] + 3 * p[1] - p[0];
+    double params[2];
+    int solutions;
+    solutions = solveQuadratic( params, a2.x, a1.x, a0.x );
+    for ( int i = 0; i < solutions; ++i )
+        if ( params[i] > 0 && params[i] < 1 )
+            b.addPoint( point( params[i] ) );
+    solutions = solveQuadratic( params, a2.y, a1.y, a0.y );
+    for ( int i = 0; i < solutions; ++i )
+        if ( params[i] > 0 && params[i] < 1 )
+            b.addPoint( point( params[i] ) );
+}
+
+void LinearSegment::moveStartPoint(Point2 to) {
+    p[0] = to;
+}
+
+void QuadraticSegment::moveStartPoint(Point2 to) {
+    Vector2 origSDir = p[0]-p[1];
+    Point2 origP1 = p[1];
+    p[1] += crossProduct(p[0]-p[1], to-p[0])/crossProduct(p[0]-p[1], p[2]-p[1])*(p[2]-p[1]);
+    p[0] = to;
+    if (dotProduct(origSDir, p[0]-p[1]) < 0)
+        p[1] = origP1;
+}
+
+void CubicSegment::moveStartPoint(Point2 to) {
+    p[1] += to-p[0];
+    p[0] = to;
+}
+
+void LinearSegment::moveEndPoint(Point2 to) {
+    p[1] = to;
+}
+
+void QuadraticSegment::moveEndPoint(Point2 to) {
+    Vector2 origEDir = p[2]-p[1];
+    Point2 origP1 = p[1];
+    p[1] += crossProduct(p[2]-p[1], to-p[2])/crossProduct(p[2]-p[1], p[0]-p[1])*(p[0]-p[1]);
+    p[2] = to;
+    if (dotProduct(origEDir, p[2]-p[1]) < 0)
+        p[1] = origP1;
+}
+
+void CubicSegment::moveEndPoint(Point2 to) {
+    p[2] += to-p[3];
+    p[3] = to;
+}
+
+void LinearSegment::splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const {
+    part1 = new LinearSegment(p[0], point(1/3.), color);
+    part2 = new LinearSegment(point(1/3.), point(2/3.), color);
+    part3 = new LinearSegment(point(2/3.), p[1], color);
+}
+
+void QuadraticSegment::splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const {
+    part1 = new QuadraticSegment(p[0], mix(p[0], p[1], 1/3.), point(1/3.), color);
+    part2 = new QuadraticSegment(point(1/3.), mix(mix(p[0], p[1], 5/9.), mix(p[1], p[2], 4/9.), .5), point(2/3.), color);
+    part3 = new QuadraticSegment(point(2/3.), mix(p[1], p[2], 2/3.), p[2], color);
+}
+
+void CubicSegment::splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const {
+    part1 = new CubicSegment(p[0], p[0] == p[1] ? p[0] : mix(p[0], p[1], 1/3.), mix(mix(p[0], p[1], 1/3.), mix(p[1], p[2], 1/3.), 1/3.), point(1/3.), color);
+    part2 = new CubicSegment(point(1/3.),
+        mix(mix(mix(p[0], p[1], 1/3.), mix(p[1], p[2], 1/3.), 1/3.), mix(mix(p[1], p[2], 1/3.), mix(p[2], p[3], 1/3.), 1/3.), 2/3.),
+        mix(mix(mix(p[0], p[1], 2/3.), mix(p[1], p[2], 2/3.), 2/3.), mix(mix(p[1], p[2], 2/3.), mix(p[2], p[3], 2/3.), 2/3.), 1/3.),
+        point(2/3.), color);
+    part3 = new CubicSegment(point(2/3.), mix(mix(p[1], p[2], 2/3.), mix(p[2], p[3], 2/3.), 2/3.), p[2] == p[3] ? p[3] : mix(p[2], p[3], 2/3.), p[3], color);
+}
+    
+bool LinearSegment::isDegenerate() const {
+    return p[0].same(p[1]);
+}
+    
+bool QuadraticSegment::isDegenerate() const {
+    return p[0].same(p[2]);
+}
+
+bool CubicSegment::isDegenerate() const {
+    return p[0].same(p[3]) && (p[0].same(p[1]) || p[2].same(p[1]));
+}
+
+/// Check how many times a ray from point R extending to the +X direction intersects
+/// the given segment:
+///  0 = no intersection or co-linear
+/// +1 = intersection increasing in the Y axis
+/// -1 = intersection decreasing in the Y axis
+static int crossLine(const Point2& r, const Point2& p0, const Point2& p1, EdgeSegment::CrossingCallback* cb) {
+    if (r.y < min(p0.y, p1.y))
+        return 0;
+    if (r.y >= max(p0.y, p1.y))
+        return 0;
+    if (r.x >= max(p0.x, p1.x))
+        return 0;
+    // Intersect the line at r.y and see if the intersection is before or after the origin.
+    double xintercept = (p0.x + (r.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y));
+    if (r.x < xintercept) {
+        int w = (p0.y < p1.y) ? 1 : -1;
+        if( cb != NULL ) {
+            cb->intersection(Point2(xintercept, r.y), w);
+        }
+        return w;
+    }
+    return 0;
+}
+
+/// Check how many times a ray from point R extending to the +X direction intersects
+/// the given segment:
+///  0 = no intersection or co-linear
+/// +1 = for each intersection increasing in the Y axis
+/// -1 = for each intersection decreasing in the Y axis
+static int crossQuad(const Point2& r, const Point2& p0, const Point2& c0, const Point2& p1, int depth, EdgeSegment::CrossingCallback* cb) {
+    if (r.y < min(p0.y, min(c0.y, p1.y)))
+        return 0;
+    if (r.y > max(p0.y, max(c0.y, p1.y)))
+        return 0;
+    if (r.x >= max(p0.x, max(c0.x, p1.x)))
+        return 0;
+        
+    // Is the quadratic segment actually a horizontal line?
+    if (p0.y == p1.y && p0.y == c0.y)
+    	return 0;
+
+    // Recursively subdivide the curve to find the intersection point(s). If we haven't
+    // converged on a solution by a given depth, just treat it as a linear segment
+    // and call the approximation good enough.
+    if( depth > 30 )
+        return crossLine(r, p0, p1, cb);
+
+    depth++;
+
+    Point2 mc0 = (p0 + c0) * 0.5;
+    Point2 mc1 = (c0 + p1) * 0.5;
+    Point2 mid = (mc0 + mc1) * 0.5;
+
+    return crossQuad(r, p0, mc0, mid, depth, cb) + crossQuad(r, mid, mc1, p1, depth, cb);
+}
+
+/// Check how many times a ray from point R extending to the +X direction intersects
+/// the given segment:
+///  0 = no intersection or co-linear
+/// +1 = for each intersection increasing in the Y axis
+/// -1 = for each intersection decreasing in the Y axis
+static int crossCubic(const Point2& r, const Point2& p0, const Point2& c0, const Point2& c1, const Point2& p1, int depth, EdgeSegment::CrossingCallback* cb) {
+    if (r.y < min(p0.y, min(c0.y, min(c1.y, p1.y))))
+        return 0;
+    if (r.y > max(p0.y, max(c0.y, max(c1.y, p1.y))))
+        return 0;
+    if (r.x >= max(p0.x, max(c0.x, max(c1.x, p1.x))))
+        return 0;
+        
+    // Is it a flat horizontal line?
+    if (p0.y == p1.y && p0.y == c0.y && p0.y == c1.y)
+    	return 0;
+    
+    // Recursively subdivide the curve to find the intersection point(s). If we haven't
+    // converged on a solution by a given depth, just treat it as a linear segment
+    // and call the approximation good enough.
+    if( depth > 30 )
+        return crossLine(r, p0, p1, cb);
+    
+    depth++;
+    
+    Point2 mid = (c0 + c1) * 0.5;
+    Point2 c00 = (p0 + c0) * 0.5;
+    Point2 c11 = (c1 + p1) * 0.5;
+    Point2 c01 = (c00 + mid) * 0.5;
+    Point2 c10 = (c11 + mid) * 0.5;
+    
+    mid = (c01 + c10) * 0.5;
+    
+    return crossCubic(r, p0, c00, c01, mid, depth, cb) + crossCubic(r, mid, c10, c11, p1, depth, cb);
+}
+    
+    
+int LinearSegment::crossings(const Point2 &r, CrossingCallback* cb) const {
+    return crossLine(r, p[0], p[1], cb);
+}
+
+    
+int QuadraticSegment::crossings(const Point2 &r, CrossingCallback* cb) const {
+    return crossQuad(r, p[0], p[1], p[2], 0, cb);
+}
+
+    
+int CubicSegment::crossings(const Point2 &r, CrossingCallback* cb) const {
+    return crossCubic(r, p[0], p[1], p[2], p[3], 0, cb);
+}
+    
+}

--- a/edge-segments.h
+++ b/edge-segments.h
@@ -1,0 +1,161 @@
+
+#pragma once
+
+#include <vector>
+
+#include "Vector2.h"
+#include "SignedDistance.h"
+#include "EdgeColor.h"
+
+namespace msdfgen {
+
+class CircleBounds
+{
+    Point2  centre;
+    double  radius;
+    std::vector<Point2> edgePoints;
+
+    inline void circlefromPoints( const Point2& p0, const Point2& p1 );
+    inline void circlefromPoints( const Point2& p0, const Point2& p1, const Point2& p2 );
+
+public:
+    CircleBounds() : radius( -1.0 )
+    {
+        edgePoints.reserve( 3 );
+    }
+
+    void addPoint( const Point2& p );
+
+    double minDistance( const Point2& p )
+    {
+        return (p - centre).length() - radius;
+    }
+};
+
+// Parameters for iterative search of closest point on a cubic Bezier curve. Increase for higher precision.
+#define MSDFGEN_CUBIC_SEARCH_STARTS 4
+#define MSDFGEN_CUBIC_SEARCH_STEPS 4
+
+/// An abstract edge segment.
+class EdgeSegment {
+
+public:
+    EdgeColor color;
+
+    EdgeSegment(EdgeColor edgeColor = WHITE) : color(edgeColor) { }
+    virtual ~EdgeSegment() { }
+    /// Creates a copy of the edge segment.
+    virtual EdgeSegment * clone() const = 0;
+    /// Returns the point on the edge specified by the parameter (between 0 and 1).
+    virtual Point2 point(double param) const = 0;
+    /// Returns the direction the edge has at the point specified by the parameter.
+    virtual Vector2 direction(double param) const = 0;
+    /// Returns the minimum signed distance between origin and the edge.
+    virtual SignedDistance signedDistance(Point2 origin, double &param) const = 0;
+    /// Converts a previously retrieved signed distance from origin to pseudo-distance.
+    virtual void distanceToPseudoDistance(SignedDistance &distance, Point2 origin, double param) const;
+    /// Adjusts the bounding box to fit the edge segment.
+    virtual void bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const = 0;
+    /// Adjusts the bounding circle to fit the edge segment.
+    virtual void circleBounds(CircleBounds& b) const = 0;
+
+    /// Moves the start point of the edge segment.
+    virtual void moveStartPoint(Point2 to) = 0;
+    /// Moves the end point of the edge segment.
+    virtual void moveEndPoint(Point2 to) = 0;
+    /// Splits the edge segments into thirds which together represent the original edge.
+    virtual void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const = 0;
+    
+    virtual bool isDegenerate() const = 0;
+
+    
+    
+    class CrossingCallback {
+    public:
+        virtual ~CrossingCallback() {}
+        /// Callback for receiving intersection points. Winding is either:
+        /// +1 if the segment is increasing in the Y axis
+        /// -1 if the segment is decreasing in the Y axis
+        virtual void intersection(const Point2& p, int winding) = 0;
+    };
+    
+    /// Calculate how many times the segment intersects the infinite ray that extends
+    /// to the right (+X) from the given point. Returns:
+    ///  0 for no intersection (or co-linear)
+    /// +1 for each intersection where Y is increasing
+    /// -1 for each intersection where Y is decreasing.
+    virtual int crossings(const Point2 &r, CrossingCallback *cb = NULL) const = 0;
+    
+    
+};
+
+/// A line segment.
+class LinearSegment : public EdgeSegment {
+
+public:
+    Point2 p[2];
+
+    LinearSegment(Point2 p0, Point2 p1, EdgeColor edgeColor = WHITE);
+    LinearSegment * clone() const;
+    Point2 point(double param) const;
+    Vector2 direction(double param) const;
+    SignedDistance signedDistance(Point2 origin, double &param) const;
+    void bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const;
+    void circleBounds(CircleBounds& b) const;
+
+    void moveStartPoint(Point2 to);
+    void moveEndPoint(Point2 to);
+    void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
+    
+    bool isDegenerate() const;
+
+    int crossings(const Point2 &r, CrossingCallback *cb = NULL) const;
+};
+
+/// A quadratic Bezier curve.
+class QuadraticSegment : public EdgeSegment {
+
+public:
+    Point2 p[3];
+
+    QuadraticSegment(Point2 p0, Point2 p1, Point2 p2, EdgeColor edgeColor = WHITE);
+    QuadraticSegment * clone() const;
+    Point2 point(double param) const;
+    Vector2 direction(double param) const;
+    SignedDistance signedDistance(Point2 origin, double &param) const;
+    void bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const;
+    void circleBounds(CircleBounds& b) const;
+
+    void moveStartPoint(Point2 to);
+    void moveEndPoint(Point2 to);
+    void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
+
+    bool isDegenerate() const;
+
+    int crossings(const Point2 &r, CrossingCallback *cb = NULL) const;
+};
+
+/// A cubic Bezier curve.
+class CubicSegment : public EdgeSegment {
+
+public:
+    Point2 p[4];
+
+    CubicSegment(Point2 p0, Point2 p1, Point2 p2, Point2 p3, EdgeColor edgeColor = WHITE);
+    CubicSegment * clone() const;
+    Point2 point(double param) const;
+    Vector2 direction(double param) const;
+    SignedDistance signedDistance(Point2 origin, double &param) const;
+    void bounds(double &l, double &b, double &r, double &t, CircleBounds* circleBounds) const;
+    void circleBounds(CircleBounds& b) const;
+
+    void moveStartPoint(Point2 to);
+    void moveEndPoint(Point2 to);
+    void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
+
+    bool isDegenerate() const;
+
+    int crossings(const Point2 &r, CrossingCallback *cb = NULL) const;
+};
+
+}

--- a/msdfgen.cpp
+++ b/msdfgen.cpp
@@ -1,0 +1,745 @@
+
+#include "../msdfgen.h"
+
+#include "arithmetics.hpp"
+#include <algorithm> // for std::sort
+
+using namespace std; // to access signbit, not all libraries put signbit in std
+
+namespace msdfgen {
+
+struct MultiDistance {
+    double r, g, b;
+    double med;
+};
+
+static inline bool pixelClash(const FloatRGB &a, const FloatRGB &b, double threshold) {
+    // Only consider pair where both are on the inside or both are on the outside
+    bool aIn = (a.r > .5f)+(a.g > .5f)+(a.b > .5f) >= 2;
+    bool bIn = (b.r > .5f)+(b.g > .5f)+(b.b > .5f) >= 2;
+    if (aIn != bIn) return false;
+    // If the change is 0 <-> 1 or 2 <-> 3 channels and not 1 <-> 1 or 2 <-> 2, it is not a clash
+    if ((a.r > .5f && a.g > .5f && a.b > .5f) || (a.r < .5f && a.g < .5f && a.b < .5f)
+        || (b.r > .5f && b.g > .5f && b.b > .5f) || (b.r < .5f && b.g < .5f && b.b < .5f))
+        return false;
+    // Find which color is which: _a, _b = the changing channels, _c = the remaining one
+    float aa, ab, ba, bb, ac, bc;
+    if ((a.r > .5f) != (b.r > .5f) && (a.r < .5f) != (b.r < .5f)) {
+        aa = a.r, ba = b.r;
+        if ((a.g > .5f) != (b.g > .5f) && (a.g < .5f) != (b.g < .5f)) {
+            ab = a.g, bb = b.g;
+            ac = a.b, bc = b.b;
+        } else if ((a.b > .5f) != (b.b > .5f) && (a.b < .5f) != (b.b < .5f)) {
+            ab = a.b, bb = b.b;
+            ac = a.g, bc = b.g;
+        } else
+            return false; // this should never happen
+    } else if ((a.g > .5f) != (b.g > .5f) && (a.g < .5f) != (b.g < .5f)
+        && (a.b > .5f) != (b.b > .5f) && (a.b < .5f) != (b.b < .5f)) {
+        aa = a.g, ba = b.g;
+        ab = a.b, bb = b.b;
+        ac = a.r, bc = b.r;
+    } else
+        return false;
+    // Find if the channels are in fact discontinuous
+    return (fabsf(aa-ba) >= threshold)
+        && (fabsf(ab-bb) >= threshold)
+        && fabsf(ac-.5f) >= fabsf(bc-.5f); // Out of the pair, only flag the pixel farther from a shape edge
+}
+
+void msdfErrorCorrection(Bitmap<FloatRGB> &output, const Vector2 &threshold) {
+    std::vector<std::pair<int, int> > clashes;
+    int w = output.width(), h = output.height();
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < w; ++x) {
+            if ((x > 0 && pixelClash(output(x, y), output(x-1, y), threshold.x))
+                || (x < w-1 && pixelClash(output(x, y), output(x+1, y), threshold.x))
+                || (y > 0 && pixelClash(output(x, y), output(x, y-1), threshold.y))
+                || (y < h-1 && pixelClash(output(x, y), output(x, y+1), threshold.y)))
+                clashes.push_back(std::make_pair(x, y));
+        }
+    for (std::vector<std::pair<int, int> >::const_iterator clash = clashes.begin(); clash != clashes.end(); ++clash) {
+        FloatRGB &pixel = output(clash->first, clash->second);
+        float med = median(pixel.r, pixel.g, pixel.b);
+        pixel.r = med, pixel.g = med, pixel.b = med;
+    }
+}
+    
+/// A utility structure for holding winding spans for a single horizontal scanline.
+/// First initialize a row by calling collect(), then use advance() to walk the row
+/// and determine "inside"-ness as you go.
+struct WindingSpanner: public EdgeSegment::CrossingCallback {
+    
+    std::vector<std::pair<double, int>> crossings;
+    
+    FillRule fillRule;
+    
+    WindingSpanner(): curW(0) {
+        curSpan = crossings.cend();
+    }
+    
+    void collect(const Shape& shape, const Point2& p) {
+        fillRule = shape.fillRule;
+        crossings.clear();
+        for (std::vector<Contour>::const_iterator contour = shape.contours.cbegin(); contour != shape.contours.cend(); ++contour) {
+            for (std::vector<EdgeHolder>::const_iterator e = contour->edges.cbegin(); e != contour->edges.cend(); ++e) {
+                (*e)->crossings(p, this);
+            }
+        }
+        
+        // Make sure we've collected them all in increasing x order.
+        std::sort(crossings.begin(), crossings.end(), compareX);
+        
+        // And set up a traversal.
+        if( fillRule == FillRule::EvenOdd )
+            curW = 1;
+        else
+            curW = 0;
+        curSpan = crossings.cbegin();
+    }
+    
+    /// Scan to the provided X coordinate and use the winding rule to return the current sign as either:
+    /// -1 = pixel is "outside" the shape (i.e. not filled)
+    /// +1 = pixel is "inside" the shape (i.e. filled)
+    /// (Note: This is actually the inverse of the final distance field sign.)
+    int advanceTo(double x) {
+        while( curSpan != crossings.cend() && x > curSpan->first ) {
+            curW += curSpan->second;
+            ++curSpan;
+        }
+
+        switch( fillRule ) {
+            case FillRule::NonZero:
+                return curW != 0 ? 1 : -1;
+            case FillRule::EvenOdd:
+                return curW % 2 == 0 ? 1 : -1;
+            case FillRule::None:
+                return curSpan != crossings.cend() ? sign(curSpan->second) : 0;
+        }
+        return 0;
+    }
+    
+private:
+
+    int curW;
+    
+    std::vector<std::pair<double, int>>::const_iterator curSpan;
+    
+    void intersection(const Point2& p, int winding) {
+        crossings.push_back(std::pair<double, int>(p.x, winding));
+    }
+
+    static bool compareX(const std::pair<double,int>& a, std::pair<double,int>& b) {
+        return a.first < b.first;
+    }
+};
+    
+void generateSDF(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+ 
+    vector<CircleBounds> contourBounds;
+    contourBounds.reserve( contourCount );
+
+    double bound_l, bound_t, bound_b, bound_r;
+    shape.bounds(bound_l, bound_b, bound_r, bound_t, &contourBounds);
+
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp parallel
+#endif
+    {
+        // Spanner must be here for OpenMP to work correctly
+        WindingSpanner spanner;
+
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            
+            // Start slightly off the -X edge so we ensure we find all spans.
+            spanner.collect(shape, Vector2(bound_l - 0.5, (y + 0.5)/scale.y - translate.y));
+            
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                
+                double minDistance = INFINITY;
+                
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+
+                    // Ignore this contour if the closest it can be is above the current min distance
+                    if ( contourBounds[i].minDistance( p ) > minDistance )
+                        continue;
+
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        double dummy;
+                        double distance = fabs((*edge)->signedDistance(p, dummy).distance);
+                        if (distance < minDistance)
+                            minDistance = distance;
+                    }
+                }
+                
+                minDistance *= spanner.advanceTo(p.x);
+                output(x, row) = float(minDistance / range + 0.5);
+            }
+        }
+    }
+}
+
+void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    
+    vector<CircleBounds> contourBounds;
+    contourBounds.reserve( contourCount );
+
+    double bound_l, bound_t, bound_b, bound_r;
+    shape.bounds(bound_l, bound_b, bound_r, bound_t, &contourBounds );
+    
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp parallel
+#endif
+    {
+        // Spanner must be here for OpenMP to work correctly
+        WindingSpanner spanner;
+
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            
+            // Start slightly off the -X edge so we ensure we find all spans.
+            spanner.collect(shape, Vector2(bound_l - 0.5, (y + 0.5)/scale.y - translate.y));
+
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                
+                SignedDistance sd = SignedDistance::INFINITE;
+                const EdgeHolder *nearEdge = NULL;
+                double nearParam = 0;
+                
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+
+                    // Ignore this contour if the closest it can be is above the current min distance
+                    if ( contourBounds[i].minDistance( p ) > fabs(sd.distance) )
+                        continue;
+
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        double param;
+                        SignedDistance distance = (*edge)->signedDistance(p, param);
+                        if (distance < sd) {
+                            sd = distance;
+                            nearEdge = &*edge;
+                            nearParam = param;
+                        }
+                    }
+                }
+                
+                if (nearEdge)
+                    (*nearEdge)->distanceToPseudoDistance(sd, p, nearParam);
+                
+                double d = fabs(sd.distance) * spanner.advanceTo(p.x);
+                output(x, row) = float(d / range + 0.5);
+            }
+        }
+    }
+}
+
+void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    
+    vector<CircleBounds> contourBounds;
+    contourBounds.reserve( contourCount );
+
+    double bound_l, bound_t, bound_b, bound_r;
+    shape.bounds(bound_l, bound_b, bound_r, bound_t, &contourBounds);
+    
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp parallel
+#endif
+    {
+        // Spanner must be here for OpenMP to work correctly
+        WindingSpanner spanner;
+        
+        std::vector<MultiDistance> contourSD;
+        contourSD.resize(contourCount);
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            
+            // Start slightly off the -X edge so we ensure we find all spans.
+            spanner.collect(shape, Vector2(bound_l - 0.5, (y + 0.5)/scale.y - translate.y));
+            
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                
+                struct EdgePoint {
+                    SignedDistance minDistance;
+                    const EdgeHolder *nearEdge;
+                    double nearParam;
+                } sr, sg, sb;
+                sr.nearEdge = sg.nearEdge = sb.nearEdge = NULL;
+                sr.nearParam = sg.nearParam = sb.nearParam = 0;
+                int realSign = spanner.advanceTo(p.x);
+                
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+
+                    // Ignore this contour if the closest it can be is above the current min distance
+                    double contourMinDist = contourBounds[i].minDistance( p );
+                    if ( contourMinDist > fabs( sr.minDistance.distance ) && contourMinDist > fabs( sg.minDistance.distance ) && contourMinDist > fabs( sb.minDistance.distance ) )
+                        continue;
+
+                    EdgePoint r, g, b;
+                    r.nearEdge = g.nearEdge = b.nearEdge = NULL;
+                    r.nearParam = g.nearParam = b.nearParam = 0;
+                    
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        
+                        double param;
+                        SignedDistance distance = (*edge)->signedDistance(p, param);
+                        if ((*edge)->color&RED && distance < r.minDistance) {
+                            r.minDistance = distance;
+                            r.nearEdge = &*edge;
+                            r.nearParam = param;
+                        }
+                        if ((*edge)->color&GREEN && distance < g.minDistance) {
+                            g.minDistance = distance;
+                            g.nearEdge = &*edge;
+                            g.nearParam = param;
+                        }
+                        if ((*edge)->color&BLUE && distance < b.minDistance) {
+                            b.minDistance = distance;
+                            b.nearEdge = &*edge;
+                            b.nearParam = param;
+                        }
+                    }
+                    
+                    if (r.minDistance < sr.minDistance) {
+                        sr = r;
+                    }
+                    if (g.minDistance < sg.minDistance) {
+                        sg = g;
+                    }
+                    if (b.minDistance < sb.minDistance) {
+                        sb = b;
+                    }
+                }
+                if (sr.nearEdge)
+                    (*sr.nearEdge)->distanceToPseudoDistance(sr.minDistance, p, sr.nearParam);
+                if (sg.nearEdge)
+                    (*sg.nearEdge)->distanceToPseudoDistance(sg.minDistance, p, sg.nearParam);
+                if (sb.nearEdge)
+                    (*sb.nearEdge)->distanceToPseudoDistance(sb.minDistance, p, sb.nearParam);
+
+                double dr = sr.minDistance.distance;
+                double dg = sg.minDistance.distance;
+                double db = sb.minDistance.distance;
+                
+                double med = median(dr, dg, db);
+                // Note: Use signbit() not sign() here because we need to know -0 case.
+                int medSign = signbit(med) ? -1 : 1;
+
+                if( medSign != realSign ) {
+                    dr = -dr;
+                    dg = -dg;
+                    db = -db;
+                }
+                
+                output(x, row).r = float(dr/range+.5);
+                output(x, row).g = float(dg/range+.5);
+                output(x, row).b = float(db/range+.5);
+            }
+        }
+    }
+    
+    if (edgeThreshold > 0)
+        msdfErrorCorrection(output, edgeThreshold/(scale*range));
+}
+    
+    
+
+void generateSDF_v2(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    std::vector<int> windings;
+    windings.reserve(contourCount);
+    for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+        windings.push_back(contour->winding());
+
+#ifdef MSDFGEN_USE_OPENMP
+    #pragma omp parallel
+#endif
+    {
+        std::vector<double> contourSD;
+        contourSD.resize(contourCount);
+#ifdef MSDFGEN_USE_OPENMP
+        #pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            for (int x = 0; x < w; ++x) {
+                double dummy;
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                double negDist = -SignedDistance::INFINITE.distance;
+                double posDist = SignedDistance::INFINITE.distance;
+                int winding = 0;
+
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+                    SignedDistance minDistance;
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        SignedDistance distance = (*edge)->signedDistance(p, dummy);
+                        if (distance < minDistance)
+                            minDistance = distance;
+                    }
+                    contourSD[i] = minDistance.distance;
+                    if (windings[i] > 0 && minDistance.distance >= 0 && fabs(minDistance.distance) < fabs(posDist))
+                        posDist = minDistance.distance;
+                    if (windings[i] < 0 && minDistance.distance <= 0 && fabs(minDistance.distance) < fabs(negDist))
+                        negDist = minDistance.distance;
+                }
+
+                double sd = SignedDistance::INFINITE.distance;
+                if (posDist >= 0 && fabs(posDist) <= fabs(negDist)) {
+                    sd = posDist;
+                    winding = 1;
+                    for (int i = 0; i < contourCount; ++i)
+                        if (windings[i] > 0 && contourSD[i] > sd && fabs(contourSD[i]) < fabs(negDist))
+                            sd = contourSD[i];
+                } else if (negDist <= 0 && fabs(negDist) <= fabs(posDist)) {
+                    sd = negDist;
+                    winding = -1;
+                    for (int i = 0; i < contourCount; ++i)
+                        if (windings[i] < 0 && contourSD[i] < sd && fabs(contourSD[i]) < fabs(posDist))
+                            sd = contourSD[i];
+                }
+                for (int i = 0; i < contourCount; ++i)
+                    if (windings[i] != winding && fabs(contourSD[i]) < fabs(sd))
+                        sd = contourSD[i];
+
+                output(x, row) = float(sd/range+.5);
+            }
+        }
+    }
+}
+
+void generatePseudoSDF_v2(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    std::vector<int> windings;
+    windings.reserve(contourCount);
+    for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+        windings.push_back(contour->winding());
+
+#ifdef MSDFGEN_USE_OPENMP
+    #pragma omp parallel
+#endif
+    {
+        std::vector<double> contourSD;
+        contourSD.resize(contourCount);
+#ifdef MSDFGEN_USE_OPENMP
+        #pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                double sd = SignedDistance::INFINITE.distance;
+                double negDist = -SignedDistance::INFINITE.distance;
+                double posDist = SignedDistance::INFINITE.distance;
+                int winding = 0;
+
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+                    SignedDistance minDistance;
+                    const EdgeHolder *nearEdge = NULL;
+                    double nearParam = 0;
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        double param;
+                        SignedDistance distance = (*edge)->signedDistance(p, param);
+                        if (distance < minDistance) {
+                            minDistance = distance;
+                            nearEdge = &*edge;
+                            nearParam = param;
+                        }
+                    }
+                    if (fabs(minDistance.distance) < fabs(sd)) {
+                        sd = minDistance.distance;
+                        winding = -windings[i];
+                    }
+                    if (nearEdge)
+                        (*nearEdge)->distanceToPseudoDistance(minDistance, p, nearParam);
+                    contourSD[i] = minDistance.distance;
+                    if (windings[i] > 0 && minDistance.distance >= 0 && fabs(minDistance.distance) < fabs(posDist))
+                        posDist = minDistance.distance;
+                    if (windings[i] < 0 && minDistance.distance <= 0 && fabs(minDistance.distance) < fabs(negDist))
+                        negDist = minDistance.distance;
+                }
+
+                double psd = SignedDistance::INFINITE.distance;
+                if (posDist >= 0 && fabs(posDist) <= fabs(negDist)) {
+                    psd = posDist;
+                    winding = 1;
+                    for (int i = 0; i < contourCount; ++i)
+                        if (windings[i] > 0 && contourSD[i] > psd && fabs(contourSD[i]) < fabs(negDist))
+                            psd = contourSD[i];
+                } else if (negDist <= 0 && fabs(negDist) <= fabs(posDist)) {
+                    psd = negDist;
+                    winding = -1;
+                    for (int i = 0; i < contourCount; ++i)
+                        if (windings[i] < 0 && contourSD[i] < psd && fabs(contourSD[i]) < fabs(posDist))
+                            psd = contourSD[i];
+                }
+                for (int i = 0; i < contourCount; ++i)
+                    if (windings[i] != winding && fabs(contourSD[i]) < fabs(psd))
+                        psd = contourSD[i];
+
+                output(x, row) = float(psd/range+.5);
+            }
+        }
+    }
+}
+
+void generateMSDF_v2(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    std::vector<int> windings;
+    windings.reserve(contourCount);
+    for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+        windings.push_back(contour->winding());
+
+#ifdef MSDFGEN_USE_OPENMP
+    #pragma omp parallel
+#endif
+    {
+        std::vector<MultiDistance> contourSD;
+        contourSD.resize(contourCount);
+#ifdef MSDFGEN_USE_OPENMP
+        #pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+
+                struct EdgePoint {
+                    SignedDistance minDistance;
+                    const EdgeHolder *nearEdge;
+                    double nearParam;
+                } sr, sg, sb;
+                sr.nearEdge = sg.nearEdge = sb.nearEdge = NULL;
+                sr.nearParam = sg.nearParam = sb.nearParam = 0;
+                double d = fabs(SignedDistance::INFINITE.distance);
+                double negDist = -SignedDistance::INFINITE.distance;
+                double posDist = SignedDistance::INFINITE.distance;
+                int winding = 0;
+
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+                    EdgePoint r, g, b;
+                    r.nearEdge = g.nearEdge = b.nearEdge = NULL;
+                    r.nearParam = g.nearParam = b.nearParam = 0;
+
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        double param;
+                        SignedDistance distance = (*edge)->signedDistance(p, param);
+                        if ((*edge)->color&RED && distance < r.minDistance) {
+                            r.minDistance = distance;
+                            r.nearEdge = &*edge;
+                            r.nearParam = param;
+                        }
+                        if ((*edge)->color&GREEN && distance < g.minDistance) {
+                            g.minDistance = distance;
+                            g.nearEdge = &*edge;
+                            g.nearParam = param;
+                        }
+                        if ((*edge)->color&BLUE && distance < b.minDistance) {
+                            b.minDistance = distance;
+                            b.nearEdge = &*edge;
+                            b.nearParam = param;
+                        }
+                    }
+                    if (r.minDistance < sr.minDistance)
+                        sr = r;
+                    if (g.minDistance < sg.minDistance)
+                        sg = g;
+                    if (b.minDistance < sb.minDistance)
+                        sb = b;
+
+                    double medMinDistance = fabs(median(r.minDistance.distance, g.minDistance.distance, b.minDistance.distance));
+                    if (medMinDistance < d) {
+                        d = medMinDistance;
+                        winding = -windings[i];
+                    }
+                    if (r.nearEdge)
+                        (*r.nearEdge)->distanceToPseudoDistance(r.minDistance, p, r.nearParam);
+                    if (g.nearEdge)
+                        (*g.nearEdge)->distanceToPseudoDistance(g.minDistance, p, g.nearParam);
+                    if (b.nearEdge)
+                        (*b.nearEdge)->distanceToPseudoDistance(b.minDistance, p, b.nearParam);
+                    medMinDistance = median(r.minDistance.distance, g.minDistance.distance, b.minDistance.distance);
+                    contourSD[i].r = r.minDistance.distance;
+                    contourSD[i].g = g.minDistance.distance;
+                    contourSD[i].b = b.minDistance.distance;
+                    contourSD[i].med = medMinDistance;
+                    if (windings[i] > 0 && medMinDistance >= 0 && fabs(medMinDistance) < fabs(posDist))
+                        posDist = medMinDistance;
+                    if (windings[i] < 0 && medMinDistance <= 0 && fabs(medMinDistance) < fabs(negDist))
+                        negDist = medMinDistance;
+                }
+                if (sr.nearEdge)
+                    (*sr.nearEdge)->distanceToPseudoDistance(sr.minDistance, p, sr.nearParam);
+                if (sg.nearEdge)
+                    (*sg.nearEdge)->distanceToPseudoDistance(sg.minDistance, p, sg.nearParam);
+                if (sb.nearEdge)
+                    (*sb.nearEdge)->distanceToPseudoDistance(sb.minDistance, p, sb.nearParam);
+
+                MultiDistance msd;
+                msd.r = msd.g = msd.b = msd.med = SignedDistance::INFINITE.distance;
+                if (posDist >= 0 && fabs(posDist) <= fabs(negDist)) {
+                    msd.med = SignedDistance::INFINITE.distance;
+                    winding = 1;
+                    for (int i = 0; i < contourCount; ++i)
+                        if (windings[i] > 0 && contourSD[i].med > msd.med && fabs(contourSD[i].med) < fabs(negDist))
+                            msd = contourSD[i];
+                } else if (negDist <= 0 && fabs(negDist) <= fabs(posDist)) {
+                    msd.med = -SignedDistance::INFINITE.distance;
+                    winding = -1;
+                    for (int i = 0; i < contourCount; ++i)
+                        if (windings[i] < 0 && contourSD[i].med < msd.med && fabs(contourSD[i].med) < fabs(posDist))
+                            msd = contourSD[i];
+                }
+                for (int i = 0; i < contourCount; ++i)
+                    if (windings[i] != winding && fabs(contourSD[i].med) < fabs(msd.med))
+                        msd = contourSD[i];
+                if (median(sr.minDistance.distance, sg.minDistance.distance, sb.minDistance.distance) == msd.med) {
+                    msd.r = sr.minDistance.distance;
+                    msd.g = sg.minDistance.distance;
+                    msd.b = sb.minDistance.distance;
+                }
+
+                output(x, row).r = float(msd.r/range+.5);
+                output(x, row).g = float(msd.g/range+.5);
+                output(x, row).b = float(msd.b/range+.5);
+            }
+        }
+    }
+
+    if (edgeThreshold > 0)
+        msdfErrorCorrection(output, edgeThreshold/(scale*range));
+}
+
+void generateSDF_v1(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int w = output.width(), h = output.height();
+#ifdef MSDFGEN_USE_OPENMP
+    #pragma omp parallel for
+#endif
+    for (int y = 0; y < h; ++y) {
+        int row = shape.inverseYAxis ? h-y-1 : y;
+        for (int x = 0; x < w; ++x) {
+            double dummy;
+            Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+            SignedDistance minDistance;
+            for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+                for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                    SignedDistance distance = (*edge)->signedDistance(p, dummy);
+                    if (distance < minDistance)
+                        minDistance = distance;
+                }
+            output(x, row) = float(minDistance.distance/range+.5);
+        }
+    }
+}
+
+void generatePseudoSDF_v1(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int w = output.width(), h = output.height();
+#ifdef MSDFGEN_USE_OPENMP
+    #pragma omp parallel for
+#endif
+    for (int y = 0; y < h; ++y) {
+        int row = shape.inverseYAxis ? h-y-1 : y;
+        for (int x = 0; x < w; ++x) {
+            Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+            SignedDistance minDistance;
+            const EdgeHolder *nearEdge = NULL;
+            double nearParam = 0;
+            for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+                for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                    double param;
+                    SignedDistance distance = (*edge)->signedDistance(p, param);
+                    if (distance < minDistance) {
+                        minDistance = distance;
+                        nearEdge = &*edge;
+                        nearParam = param;
+                    }
+                }
+            if (nearEdge)
+                (*nearEdge)->distanceToPseudoDistance(minDistance, p, nearParam);
+            output(x, row) = float(minDistance.distance/range+.5);
+        }
+    }
+}
+
+void generateMSDF_v1(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
+    int w = output.width(), h = output.height();
+#ifdef MSDFGEN_USE_OPENMP
+    #pragma omp parallel for
+#endif
+    for (int y = 0; y < h; ++y) {
+        int row = shape.inverseYAxis ? h-y-1 : y;
+        for (int x = 0; x < w; ++x) {
+            Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+
+            struct {
+                SignedDistance minDistance;
+                const EdgeHolder *nearEdge;
+                double nearParam;
+            } r, g, b;
+            r.nearEdge = g.nearEdge = b.nearEdge = NULL;
+            r.nearParam = g.nearParam = b.nearParam = 0;
+
+            for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+                for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                    double param;
+                    SignedDistance distance = (*edge)->signedDistance(p, param);
+                    if ((*edge)->color&RED && distance < r.minDistance) {
+                        r.minDistance = distance;
+                        r.nearEdge = &*edge;
+                        r.nearParam = param;
+                    }
+                    if ((*edge)->color&GREEN && distance < g.minDistance) {
+                        g.minDistance = distance;
+                        g.nearEdge = &*edge;
+                        g.nearParam = param;
+                    }
+                    if ((*edge)->color&BLUE && distance < b.minDistance) {
+                        b.minDistance = distance;
+                        b.nearEdge = &*edge;
+                        b.nearParam = param;
+                    }
+                }
+
+            if (r.nearEdge)
+                (*r.nearEdge)->distanceToPseudoDistance(r.minDistance, p, r.nearParam);
+            if (g.nearEdge)
+                (*g.nearEdge)->distanceToPseudoDistance(g.minDistance, p, g.nearParam);
+            if (b.nearEdge)
+                (*b.nearEdge)->distanceToPseudoDistance(b.minDistance, p, b.nearParam);
+            output(x, row).r = float(r.minDistance.distance/range+.5);
+            output(x, row).g = float(g.minDistance.distance/range+.5);
+            output(x, row).b = float(b.minDistance.distance/range+.5);
+        }
+    }
+
+    if (edgeThreshold > 0)
+        msdfErrorCorrection(output, edgeThreshold/(scale*range));
+}
+
+}


### PR DESCRIPTION
Fixes OpenMP corruption is output images (conflicting access WindingSpanner).
Bounds testing for contours within shapes to speed up searching for nearest contour in complex shapes. Approximately 100x speed up for a shape with 2500 contours.